### PR TITLE
Fix camelize for fields with url

### DIFF
--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -8,7 +8,11 @@ defmodule Passbook.Helpers do
 
   # Camelize strings in a map
   def camelize(key) when is_binary(key) do
-    capitalized = Macro.camelize(key)
+    capitalized =
+      key
+      |> Macro.camelize()
+      |> String.replace("Url", "URL")
+
     <<first>> <> rest = capitalized
     String.downcase(<<first>>) <> rest
   end

--- a/lib/passbook.ex
+++ b/lib/passbook.ex
@@ -100,7 +100,9 @@ defmodule Passbook do
       |> Enum.map(&String.to_charlist/1)
 
     pkpass =
-      :zip.create(to_string(target_path <> "#{opts[:pass_name]}.pkpass"), files, cwd: target_path)
+      :zip.create(to_string(target_path <> "#{opts[:pass_name]}.pkpass"), files,
+        cwd: String.to_charlist(target_path)
+      )
 
     if opts[:delete_raw_pass], do: Enum.map(files, &File.rm(target_path <> to_string(&1)))
 


### PR DESCRIPTION
When the field contains the chars sequence url, it has to be fully capitalize (for instance web_service_url must become webServiceURL)